### PR TITLE
An Alternative Way to validate slug during edit link

### DIFF
--- a/app/Http/Livewire/EditLink.php
+++ b/app/Http/Livewire/EditLink.php
@@ -13,9 +13,9 @@ class EditLink extends Component
     public $is_enabled;
 
     protected $rules = [
-	        'url' => 'required|url|max:255',
-	        'slug' => 'required|alpha_dash|min:3|max:100|unique:links,slug',
-	        'is_enabled' => 'required|boolean',
+        'url' => 'required|url|max:255',
+        'slug' => 'required|alpha_dash|min:3|max:100|unique:links,slug',
+        'is_enabled' => 'required|boolean',
     ];
 
     public function updated($property)

--- a/app/Http/Livewire/EditLink.php
+++ b/app/Http/Livewire/EditLink.php
@@ -13,9 +13,9 @@ class EditLink extends Component
     public $is_enabled;
 
     protected $rules = [
-		'url' => 'required|url|max:255',
-		'slug' => 'required|alpha_dash|min:3|max:100|unique:links,slug',
-		'is_enabled' => 'required|boolean',
+	        'url' => 'required|url|max:255',
+	        'slug' => 'required|alpha_dash|min:3|max:100|unique:links,slug',
+	        'is_enabled' => 'required|boolean',
     ];
 
     public function updated($property)

--- a/app/Http/Livewire/EditLink.php
+++ b/app/Http/Livewire/EditLink.php
@@ -12,7 +12,7 @@ class EditLink extends Component
     public $slug;
     public $is_enabled;
 
-    public $rules = [
+    protected $rules = [
 		'url' => 'required|url|max:255',
 		'slug' => 'required|alpha_dash|min:3|max:100|unique:links,slug',
 		'is_enabled' => 'required|boolean',

--- a/app/Http/Livewire/EditLink.php
+++ b/app/Http/Livewire/EditLink.php
@@ -25,7 +25,7 @@ class EditLink extends Component
 
     public function mount($link)
     {
-	$this->rules['slug'] .= ",{$link->id}";
+        $this->rules['slug'] .= ",{$link->id}";
         $this->link_id = $link->id;
         $this->url = $link->url;
         $this->slug = $link->slug;

--- a/app/Http/Livewire/EditLink.php
+++ b/app/Http/Livewire/EditLink.php
@@ -12,14 +12,11 @@ class EditLink extends Component
     public $slug;
     public $is_enabled;
 
-    public function rules()
-    {
-        return [
+    public $rules = [
 		'url' => 'required|url|max:255',
-		'slug' => "required|alpha_dash|min:3|max:100|unique:links,slug,{$this->link_id}",
+		'slug' => "required|alpha_dash|min:3|max:100|unique:links,slug",
 		'is_enabled' => 'required|boolean',
-	    ];
-    }
+    ];
 
     public function updated($property)
     {
@@ -28,6 +25,7 @@ class EditLink extends Component
 
     public function mount($link)
     {
+	$this->rules['slug'] .= ",{$link->id}";
         $this->link_id = $link->id;
         $this->url = $link->url;
         $this->slug = $link->slug;

--- a/app/Http/Livewire/EditLink.php
+++ b/app/Http/Livewire/EditLink.php
@@ -16,7 +16,7 @@ class EditLink extends Component
     {
         return [
 		'url' => 'required|url|max:255',
-		'slug' => 'required|alpha_dash|min:3|max:100|unique:links,slug,'.$this->link_id,
+		'slug' => "required|alpha_dash|min:3|max:100|unique:links,slug,{$this->link_id}",
 		'is_enabled' => 'required|boolean',
 	    ];
     }

--- a/app/Http/Livewire/EditLink.php
+++ b/app/Http/Livewire/EditLink.php
@@ -14,7 +14,7 @@ class EditLink extends Component
 
     public $rules = [
 		'url' => 'required|url|max:255',
-		'slug' => "required|alpha_dash|min:3|max:100|unique:links,slug",
+		'slug' => 'required|alpha_dash|min:3|max:100|unique:links,slug',
 		'is_enabled' => 'required|boolean',
     ];
 

--- a/app/Http/Livewire/EditLink.php
+++ b/app/Http/Livewire/EditLink.php
@@ -12,11 +12,14 @@ class EditLink extends Component
     public $slug;
     public $is_enabled;
 
-    protected $rules = [
-        'url' => 'required|url|max:255',
-        'slug' => 'required|alpha_dash|min:3|max:100',
-        'is_enabled' => 'required|boolean',
-    ];
+    public function rules()
+    {
+        return [
+		'url' => 'required|url|max:255',
+		'slug' => 'required|alpha_dash|min:3|max:100|unique:links,slug,'.$this->link_id,
+		'is_enabled' => 'required|boolean',
+	    ];
+    }
 
     public function updated($property)
     {
@@ -34,20 +37,10 @@ class EditLink extends Component
     public function saveLink()
     {
         $link = Link::findOrFail($this->link_id);
-
-        if ($this->checkSlugExists()) {
-            return $this->addError('slug', 'This slug is already taken.');
-        }
         
         $link->update($this->validate());
 
         return redirect(route('links'));
-    }
-
-    private function checkSlugExists()
-    {
-        $link = Link::where('slug', $this->slug)->first();
-        return $link && $link->id !== $this->link_id;
     }
 
     public function render()


### PR DESCRIPTION
A proposed alternative way to validate unique column in links table that uses rules() method instead of property.
Thanks @davidgrzyb for an amazing Youtube series